### PR TITLE
allow for a persistent MEDIA_ROOT

### DIFF
--- a/no_drama/build_skel/lib/dfd.py
+++ b/no_drama/build_skel/lib/dfd.py
@@ -12,17 +12,18 @@ root = os.path.realpath(os.path.join(this_dir, '../'))
 
 paths = {'environment': 'environment.json',
          'static_in': '../../static.in',
-         'build_static_in' : 'static.in',
+         'build_static_in': 'static.in',
          'extended_python_path': '../../lib',
          'static_out': 'static',
          'update_symlink': '../../current',
          'debug_if_exists': '../../DEBUG',
-         'secret_key':'../../SECRET_KEY',
+         'persistent_media_root': '../../MEDIA_ROOT',
+         'secret_key': '../../SECRET_KEY',
          'pre_wsgi': 'pre-wsgi.py-fragment',
          'post_wsgi': 'post-wsgi.py-fragment',
          'build_lib': 'lib',
-         'aux':'aux',
-         'root':'.'
+         'aux': 'aux',
+         'root': '.'
          }
 
 pathfiles_glob = os.path.join(root, 'paths.d/*.json')

--- a/no_drama/build_skel/lib/dfd_settings.py
+++ b/no_drama/build_skel/lib/dfd_settings.py
@@ -10,11 +10,11 @@ else:
     raise ImportError
 
 
-
 static_in = dfd.get_path('static_in')
 build_static_in = dfd.get_path('build_static_in')
 static_out = dfd.get_path('static_out')
 secret_key_path = dfd.get_path_if_exists('secret_key')
+media_root_path = dfd.get_path_if_exists('persistent_media_root')
 
 
 DEBUG = bool(dfd.get_path_if_exists('debug_if_exists'))
@@ -38,3 +38,6 @@ if EXTENDED_STATICFILES_DIRS:
         STATICFILES_DIRS = EXTENDED_STATICFILES_DIRS
 
 STATIC_ROOT = static_out
+
+if media_root_path:
+    MEDIA_ROOT = media_root_path


### PR DESCRIPTION
If a directory at the same level as 'versions' exists called 'MEDIA_ROOT', set it as the django MEDIA_ROOT.

The name of this directory can be changed by overriding the path variable 'persistent_media_root'
