### PR TITLE
Raise an exception if pip.main() returns anything other than 0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: python
+sudo: false
+python: 3.4
+env:
+    - TOX_ENV=py34
+    - TOX_ENV=py27
+    - TOX_ENV=flake8
+install:
+    - pip install tox
+script:
+    - tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,5 @@ install:
     - pip install tox
 script:
     - tox
+notifications:
+    email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ python: 3.4
 env:
     - TOX_ENV=py34
     - TOX_ENV=py27
-    - TOX_ENV=flake8
 install:
     - pip install tox
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: python
 sudo: false
-python: 3.4
+python: 3.5
 env:
-    - TOX_ENV=py34
+    - TOX_ENV=py35
     - TOX_ENV=py27
 install:
     - pip install tox

--- a/no_drama/pip_automation.py
+++ b/no_drama/pip_automation.py
@@ -6,7 +6,7 @@ import hashlib
 def hash_for_path(path):
     hasher = hashlib.sha1()
     with open(path, 'rb') as afile:
-        buf = afile.read()
+        buf = afile.read().encode('utf-8')
         hasher.update(buf)
     return hasher.hexdigest()
 

--- a/no_drama/pip_automation.py
+++ b/no_drama/pip_automation.py
@@ -45,7 +45,13 @@ def save_wheels(destination, packages=[], requirements_paths=[]):
             requirements_cache_args += ['-r', path]
             record_caches.append(path)
 
-    pip.main(cache_wheel_command_prefix + packages + requirements_cache_args)
-    pip.main(save_wheel_command_prefix + packages + requirements_install_args)
+    status = pip.main(cache_wheel_command_prefix + packages + requirements_cache_args)
+    if status != 0:
+        raise ValueError("non-zero return from pip.main() when caching")
+
+    status = pip.main(save_wheel_command_prefix + packages + requirements_install_args)
+    if status != 0:
+        raise ValueError("non-zero return from pip.main() when installing")
+
     for path in record_caches:
         record_req_cached(path)

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,0 +1,8 @@
+configparser==3.5.0
+enum34==1.1.6
+flake8==3.0.4 
+mccabe==0.5.2 
+pycodestyle==2.0.0 
+pyflakes==1.2.3
+funcsigs==1.0.2 
+mock==2.0.0

--- a/setup.py
+++ b/setup.py
@@ -9,11 +9,15 @@ setup(
     entry_points={
         'console_scripts':[
             'no-drama=no_drama.__main__:main'
-            ]
-        },
+        ]
+    },
     install_requires=[
         'wheel>=0.29.0',
         'pip>=8.1.1',
         'setuptools>=20.2.2',
-        ]
+    ],
+    tests_require = [
+        'mock',
+    ],
+    test_suite='tests',
 )

--- a/tests/test_pip_automation.py
+++ b/tests/test_pip_automation.py
@@ -1,0 +1,94 @@
+from __future__ import print_function
+
+import unittest
+
+# Some Python 2-friendly imports
+try:
+    import unittest.mock as mock
+except ImportError:
+    import mock
+
+import no_drama.pip_automation as pip_automation
+
+
+class TestPipAutomation(unittest.TestCase):
+
+    def test_hash_for_path(self):
+        with mock.patch('no_drama.pip_automation.open',
+                mock.mock_open(read_data='testtest'), create=True):
+            result = pip_automation.hash_for_path('/test-path')
+            self.assertEqual(result,
+                    '51abb9636078defbf888d8457a7c76f85c8f114c')
+
+    @mock.patch('no_drama.pip_automation.hash_for_path')
+    def test_cache_marker_for_path(self, mock_hash_for_path):
+        mock_hash_for_path.return_value = \
+                '51abb9636078defbf888d8457a7c76f85c8f114c'
+        result = pip_automation.cache_marker_for_path('/test-path')
+        self.assertEqual(result,
+                'requirements_hashes/51abb9636078defbf888d8457a7c76f85c8f114c')
+
+    @mock.patch('os.path.exists')
+    @mock.patch('no_drama.pip_automation.cache_marker_for_path')
+    def test_is_cache_update_required_false(self, 
+            mock_cache_marker_for_path, mock_os_path_exists):
+        mock_cache_marker_for_path.return_value = \
+                'requirements_hashes/51abb9636078defbf888d8457a7c76f85c8f114c'
+        mock_os_path_exists.return_value = True
+        result = pip_automation.is_cache_update_required('/test-path')
+        self.assertFalse(result)
+
+    @mock.patch('os.path.exists')
+    @mock.patch('no_drama.pip_automation.cache_marker_for_path')
+    def test_is_cache_update_required_true(self, 
+            mock_cache_marker_for_path, mock_os_path_exists):
+        mock_cache_marker_for_path.return_value = \
+                'requirements_hashes/51abb9636078defbf888d8457a7c76f85c8f114c'
+        mock_os_path_exists.return_value = False
+        result = pip_automation.is_cache_update_required('/test-path')
+        self.assertTrue(result)
+
+    @mock.patch('os.mkdir')
+    @mock.patch('os.path.exists')
+    @mock.patch('no_drama.pip_automation.cache_marker_for_path')
+    def test_record_req_cached_dir_does_not_exist(self, 
+            mock_cache_marker_for_path, mock_os_path_exists, mock_os_mkdir):
+        mock_cache_marker_for_path.return_value = \
+                'requirements_hashes/51abb9636078defbf888d8457a7c76f85c8f114c'
+        mock_os_path_exists.return_value = False
+
+        mock_open_mock = mock.mock_open()
+        with mock.patch('no_drama.pip_automation.open', 
+                mock_open_mock, create=True):
+            result = pip_automation.record_req_cached('/test-path')
+
+        mock_open_mock().write.assert_called_once_with('')
+        self.assertTrue(mock_os_mkdir.called)
+
+    @mock.patch('os.mkdir')
+    @mock.patch('os.path.exists')
+    @mock.patch('no_drama.pip_automation.cache_marker_for_path')
+    def test_record_req_cached_dir_exists(self, 
+            mock_cache_marker_for_path, mock_os_path_exists, mock_os_mkdir):
+        mock_cache_marker_for_path.return_value = \
+                'requirements_hashes/51abb9636078defbf888d8457a7c76f85c8f114c'
+        mock_os_path_exists.return_value = True
+
+        mock_open_mock = mock.mock_open()
+        with mock.patch('no_drama.pip_automation.open', 
+                mock_open_mock, create=True):
+            result = pip_automation.record_req_cached('/test-path')
+
+        mock_open_mock().write.assert_called_once_with('')
+        self.assertFalse(mock_os_mkdir.called)
+
+    @mock.patch('no_drama.pip_automation.is_cache_update_required')
+    @mock.patch('no_drama.pip_automation.record_req_cached')
+    @mock.patch('no_drama.pip_automation.pip.main')
+    def test_save_wheels(self, mock_pip_main,
+            mock_record_req_cached, mock_is_cache_update_required):
+        mock_is_cache_update_required.return_value = False
+        mock_pip_main.return_value = 0
+        pip_automation.save_wheels('/bootsrap_wheels', ['some', 'packages'], 
+                ['first.txt', 'second.txt'])
+        self.assertEqual(mock_pip_main.call_count, 2)

--- a/tests/test_pip_automation.py
+++ b/tests/test_pip_automation.py
@@ -92,3 +92,25 @@ class TestPipAutomation(unittest.TestCase):
         pip_automation.save_wheels('/bootsrap_wheels', ['some', 'packages'], 
                 ['first.txt', 'second.txt'])
         self.assertEqual(mock_pip_main.call_count, 2)
+
+    @mock.patch('no_drama.pip_automation.is_cache_update_required')
+    @mock.patch('no_drama.pip_automation.record_req_cached')
+    @mock.patch('no_drama.pip_automation.pip.main')
+    def test_save_wheels_pip_failure(self, mock_pip_main,
+            mock_record_req_cached, mock_is_cache_update_required):
+        mock_is_cache_update_required.return_value = False
+
+        # Fail the second call to pip.main()
+        mock_pip_main.side_effect = [0, 1]
+        with self.assertRaises(ValueError):
+            pip_automation.save_wheels('/bootsrap_wheels', ['some', 'packages'], 
+                    ['first.txt', 'second.txt'])
+            self.assertEqual(mock_pip_main.call_count, 2)
+
+        # Fail the first call to pip.main()
+        mock_pip_main.reset_mock()
+        mock_pip_main.side_effect = [1, 0]
+        with self.assertRaises(ValueError):
+            pip_automation.save_wheels('/bootsrap_wheels', ['some', 'packages'], 
+                    ['first.txt', 'second.txt'])
+            self.assertEqual(mock_pip_main.call_count, 1)

--- a/tests/test_pip_automation.py
+++ b/tests/test_pip_automation.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import unittest
 
 # Some Python 2-friendly imports

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,14 @@
+[tox]
+envlist = py27,py35
+skipsdist = True
+
+[testenv]
+deps =
+    -rrequirements_test.txt
+commands = python setup.py test
+
+[testenv:flake8]
+deps =
+    -rrequirements_test.txt
+commands =
+    flake8 no_drama

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34
+envlist = py27,py35
 skipsdist = True
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py35
+envlist = py27,py34
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
This PR adds a check to the calls to pip.main() that will raise an exception if pip.main() returns non-zero. This should cause any failure in pip to fail the build at this stage.

Additionally, this PR adds tests for the pip_automation module, tox, and Travis, so we can start covering drama-free-Django with tests. 😊

@rosskarchner 
