### PR TITLE
put custom paths in paths.d

### DIFF
--- a/no_drama/__main__.py
+++ b/no_drama/__main__.py
@@ -125,7 +125,7 @@ def inject_configuration(cli_args):
         if cli_args.paths:
             build_zip.write(
                 cli_args.paths, os.path.join(
-                    zip_root, 'paths.json'))
+                    zip_root, 'paths.d/1_custom.json'))
 
         if cli_args.prepend_wsgi:
             build_zip.write(cli_args.prepend_wsgi,


### PR DESCRIPTION
An earlier iteration of DFD stored path configuration in 'paths.json'. This was later moved to a paths.d directory, but the CLI logic was never updated to allow for it.

This is useful if we want to override default paths, for example static files.

Then at release time we can invoke `no-drama release` with `--paths paths.json`, where paths.json looks like this:

```json
{"static_out": "../../static"} 
```
(paths are relative to the 'versions/whatever' directory)