### PR TITLE
Let pip cache

### DIFF
--- a/no_drama/pip_automation.py
+++ b/no_drama/pip_automation.py
@@ -3,23 +3,6 @@ import pip
 import hashlib
 
 
-def hash_for_path(path):
-    hasher = hashlib.sha1()
-    with open(path, 'rb') as afile:
-        buf = afile.read().encode('utf-8')
-        hasher.update(buf)
-    return hasher.hexdigest()
-
-
-def cache_marker_for_path(path):
-    req_hash = hash_for_path(path)
-    return 'requirements_hashes/%s' % req_hash
-
-
-def is_cache_update_required(path):
-    marker_path = cache_marker_for_path(path)
-    return not os.path.exists(marker_path)
-
 
 def record_req_cached(path):
     marker_path = cache_marker_for_path(path)
@@ -30,28 +13,15 @@ def record_req_cached(path):
 
 
 def save_wheels(destination, packages=[], requirements_paths=[]):
-    cache_wheel_command_prefix = "wheel --find-links=wheelhouse --wheel-dir=wheelhouse".split()
     save_wheel_command_prefix = (
-        " wheel --find-links=wheelhouse --no-index --wheel-dir=%s" %
+        " wheel --no-deps --wheel-dir=%s" %
         destination).split()
 
     requirements_install_args = []
-    requirements_cache_args = []
 
-    record_caches = []
     for path in requirements_paths:
         requirements_install_args += ['-r', path]
-        if is_cache_update_required(path):
-            requirements_cache_args += ['-r', path]
-            record_caches.append(path)
-
-    status = pip.main(cache_wheel_command_prefix + packages + requirements_cache_args)
-    if status != 0:
-        raise ValueError("non-zero return from pip.main() when caching")
 
     status = pip.main(save_wheel_command_prefix + packages + requirements_install_args)
     if status != 0:
         raise ValueError("non-zero return from pip.main() when installing")
-
-    for path in record_caches:
-        record_req_cached(path)

--- a/no_drama/pip_automation.py
+++ b/no_drama/pip_automation.py
@@ -14,7 +14,7 @@ def record_req_cached(path):
 
 def save_wheels(destination, packages=[], requirements_paths=[]):
     save_wheel_command_prefix = (
-        " wheel --no-deps --wheel-dir=%s" %
+        " wheel --wheel-dir=%s" %
         destination).split()
 
     requirements_install_args = []

--- a/tests/test_pip_automation.py
+++ b/tests/test_pip_automation.py
@@ -11,104 +11,21 @@ import no_drama.pip_automation as pip_automation
 
 class TestPipAutomation(unittest.TestCase):
 
-    def test_hash_for_path(self):
-        with mock.patch('no_drama.pip_automation.open',
-                mock.mock_open(read_data='testtest'), create=True):
-            result = pip_automation.hash_for_path('/test-path')
-            self.assertEqual(result,
-                    '51abb9636078defbf888d8457a7c76f85c8f114c')
-
-    @mock.patch('no_drama.pip_automation.hash_for_path')
-    def test_cache_marker_for_path(self, mock_hash_for_path):
-        mock_hash_for_path.return_value = \
-                '51abb9636078defbf888d8457a7c76f85c8f114c'
-        result = pip_automation.cache_marker_for_path('/test-path')
-        self.assertEqual(result,
-                'requirements_hashes/51abb9636078defbf888d8457a7c76f85c8f114c')
-
-    @mock.patch('os.path.exists')
-    @mock.patch('no_drama.pip_automation.cache_marker_for_path')
-    def test_is_cache_update_required_false(self, 
-            mock_cache_marker_for_path, mock_os_path_exists):
-        mock_cache_marker_for_path.return_value = \
-                'requirements_hashes/51abb9636078defbf888d8457a7c76f85c8f114c'
-        mock_os_path_exists.return_value = True
-        result = pip_automation.is_cache_update_required('/test-path')
-        self.assertFalse(result)
-
-    @mock.patch('os.path.exists')
-    @mock.patch('no_drama.pip_automation.cache_marker_for_path')
-    def test_is_cache_update_required_true(self, 
-            mock_cache_marker_for_path, mock_os_path_exists):
-        mock_cache_marker_for_path.return_value = \
-                'requirements_hashes/51abb9636078defbf888d8457a7c76f85c8f114c'
-        mock_os_path_exists.return_value = False
-        result = pip_automation.is_cache_update_required('/test-path')
-        self.assertTrue(result)
-
-    @mock.patch('os.mkdir')
-    @mock.patch('os.path.exists')
-    @mock.patch('no_drama.pip_automation.cache_marker_for_path')
-    def test_record_req_cached_dir_does_not_exist(self, 
-            mock_cache_marker_for_path, mock_os_path_exists, mock_os_mkdir):
-        mock_cache_marker_for_path.return_value = \
-                'requirements_hashes/51abb9636078defbf888d8457a7c76f85c8f114c'
-        mock_os_path_exists.return_value = False
-
-        mock_open_mock = mock.mock_open()
-        with mock.patch('no_drama.pip_automation.open', 
-                mock_open_mock, create=True):
-            result = pip_automation.record_req_cached('/test-path')
-
-        mock_open_mock().write.assert_called_once_with('')
-        self.assertTrue(mock_os_mkdir.called)
-
-    @mock.patch('os.mkdir')
-    @mock.patch('os.path.exists')
-    @mock.patch('no_drama.pip_automation.cache_marker_for_path')
-    def test_record_req_cached_dir_exists(self, 
-            mock_cache_marker_for_path, mock_os_path_exists, mock_os_mkdir):
-        mock_cache_marker_for_path.return_value = \
-                'requirements_hashes/51abb9636078defbf888d8457a7c76f85c8f114c'
-        mock_os_path_exists.return_value = True
-
-        mock_open_mock = mock.mock_open()
-        with mock.patch('no_drama.pip_automation.open', 
-                mock_open_mock, create=True):
-            result = pip_automation.record_req_cached('/test-path')
-
-        mock_open_mock().write.assert_called_once_with('')
-        self.assertFalse(mock_os_mkdir.called)
-
-    @mock.patch('no_drama.pip_automation.is_cache_update_required')
-    @mock.patch('no_drama.pip_automation.record_req_cached')
     @mock.patch('no_drama.pip_automation.pip.main')
-    def test_save_wheels(self, mock_pip_main,
-            mock_record_req_cached, mock_is_cache_update_required):
-        mock_is_cache_update_required.return_value = False
+    def test_save_wheels(self, mock_pip_main):
         mock_pip_main.return_value = 0
-        pip_automation.save_wheels('/bootsrap_wheels', ['some', 'packages'], 
-                ['first.txt', 'second.txt'])
-        self.assertEqual(mock_pip_main.call_count, 2)
+        pip_automation.save_wheels('/bootsrap_wheels', ['some', 'packages'],
+                                   ['first.txt', 'second.txt'])
+        self.assertEqual(mock_pip_main.call_count, 1)
 
-    @mock.patch('no_drama.pip_automation.is_cache_update_required')
-    @mock.patch('no_drama.pip_automation.record_req_cached')
     @mock.patch('no_drama.pip_automation.pip.main')
-    def test_save_wheels_pip_failure(self, mock_pip_main,
-            mock_record_req_cached, mock_is_cache_update_required):
-        mock_is_cache_update_required.return_value = False
-
-        # Fail the second call to pip.main()
-        mock_pip_main.side_effect = [0, 1]
-        with self.assertRaises(ValueError):
-            pip_automation.save_wheels('/bootsrap_wheels', ['some', 'packages'], 
-                    ['first.txt', 'second.txt'])
-            self.assertEqual(mock_pip_main.call_count, 2)
+    def test_save_wheels_pip_failure(self, mock_pip_main):
 
         # Fail the first call to pip.main()
         mock_pip_main.reset_mock()
         mock_pip_main.side_effect = [1, 0]
         with self.assertRaises(ValueError):
-            pip_automation.save_wheels('/bootsrap_wheels', ['some', 'packages'], 
-                    ['first.txt', 'second.txt'])
+            pip_automation.save_wheels('/bootsrap_wheels',
+                                       ['some', 'packages'],
+                                       ['first.txt', 'second.txt'])
             self.assertEqual(mock_pip_main.call_count, 1)


### PR DESCRIPTION
There no longer seems to be any value in the additional complexity of trying to cache wheels, separately from adding them to the build.