### PR TITLE
keep pip version to 9.0.3 or lower (10 breaks our deployments)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,21 +2,21 @@
 
 from setuptools import setup, find_packages
 setup(
-    name = "drama-free-django",
-    version = "0.1",
-    packages = find_packages(),
-    include_package_data = True,
+    name="drama-free-django",
+    version="0.1",
+    packages=find_packages(),
+    include_package_data=True,
     entry_points={
-        'console_scripts':[
+        'console_scripts': [
             'no-drama=no_drama.__main__:main'
         ]
     },
     install_requires=[
         'wheel>=0.29.0',
-        'pip>=8.1.1',
+        'pip>=8.1.1,<=9.0.3',
         'setuptools>=20.2.2',
     ],
-    tests_require = [
+    tests_require=[
         'mock',
     ],
     test_suite='tests',


### PR DESCRIPTION
I appears that pip 10.0.0b2 (uploaded to pypi today) has a breaking change (`pip.main` removed) that disrupts deployments.

Until that is resolved, we need to keep our version for Jenkins purposes below 10.

cc @acrewdson