### PR TITLE
Restrict the version range for our wheel dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
         ]
     },
     install_requires=[
-        'wheel>=0.29.0',
+        'wheel>=0.29.0,<=0.31.0',
         'pip>=8.1.1,<=9.0.3',
         'setuptools>=20.2.2',
     ],


### PR DESCRIPTION
We use `wheel install` to install wheel files when the drama-free archive gets extracted. `wheel install` was removed in 0.32.0. This sets the upper bounds on the dependency to 0.31.0, which is known to work.