### PR TITLE
Pin the version of wheel that bootstraps the archive

### DIFF
--- a/no_drama/__main__.py
+++ b/no_drama/__main__.py
@@ -33,7 +33,7 @@ def stage_bundle(cli_args):
         shutil.copytree(build_skel, build_dir)
 
         # these are wheels needed during activation
-        bootstrap_wheels = ['virtualenv', 'pip', 'wheel', 'setuptools']
+        bootstrap_wheels = ['virtualenv', 'pip>=8.1.1,<=9.0.3', 'wheel>=0.29.0,<0.32', 'setuptools']
         bootstrap_wheels_destination = os.path.join(
             build_dir, 'bootstrap_wheels')
         save_wheels(packages=bootstrap_wheels,

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
         ]
     },
     install_requires=[
-        'wheel>=0.29.0,<=0.31.0',
+        'wheel>=0.29.0,<0.32',
         'pip>=8.1.1,<=9.0.3',
         'setuptools>=20.2.2',
     ],


### PR DESCRIPTION
Going along with #14, this does the same sort of thing for the copy of `wheel` that's used when bootstrapping the archive.