### PR TITLE
Use pip in the install instead of wheel

### DIFF
--- a/no_drama/__main__.py
+++ b/no_drama/__main__.py
@@ -33,7 +33,7 @@ def stage_bundle(cli_args):
         shutil.copytree(build_skel, build_dir)
 
         # these are wheels needed during activation
-        bootstrap_wheels = ['virtualenv', 'pip>=8.1.1,<=9.0.3', 'wheel>=0.29.0,<0.32', 'setuptools']
+        bootstrap_wheels = ['virtualenv', 'pip==18', 'setuptools']
         bootstrap_wheels_destination = os.path.join(
             build_dir, 'bootstrap_wheels')
         save_wheels(packages=bootstrap_wheels,

--- a/no_drama/build_skel/activate.sh
+++ b/no_drama/build_skel/activate.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 FILES=$DIR/bootstrap_wheels/*.whl
 for f in $FILES
@@ -15,6 +17,5 @@ SITE_PACKAGES=`find $DIR/venv -name 'site-packages'`
 echo `$DIR/venv/bin/python $DIR/lib/dfd.py build_lib`>$SITE_PACKAGES/no_drama.pth
 echo `$DIR/venv/bin/python $DIR/lib/dfd.py django_root`>>$SITE_PACKAGES/no_drama.pth
 
-$DIR/venv/bin/wheel install $DIR/wheels/*.whl --force
-$DIR/venv/bin/django-admin.py collectstatic --noinput
+$DIR/venv/bin/pip install $DIR/wheels/*.whl --force
 $DIR/venv/bin/python -m activate_phase2


### PR DESCRIPTION
This removes the dependency on the wheel package from the archive extraction and uses pip, pinned to version 18. I also removed the attempt to run `collectstatic` — we do that in Ansible.

I left the pip<=9 requirement alone in the setup.py file because I seem to recall there was an issue with pip 10+ in building some of our packages (but not installing them).

I'm happy to explore that bit a little more if anyone thinks its necessary. I think a better use of time would be in getting drama-free-django out of our pipeline.