### PR TITLE
Fix travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: python
-sudo: false
 python: 3.5
 env:
     - TOX_ENV=py35


### PR DESCRIPTION
Remove travis config for containerized testing.

Travis is moving away from using containers for its tests,
and there is no longer a need for the `sudo: false` directive.

See internal issue 3157 for more detail.