### PR TITLE
[wip] support building for multiple pythons

### DIFF
--- a/no_drama/__main__.py
+++ b/no_drama/__main__.py
@@ -1,10 +1,26 @@
 #!/usr/bin/env python
 
 import argparse
+import subprocess
 import sys
 
 from no_drama.build import stage_bundle
 from no_drama.release import inject_configuration
+
+
+SEEN_PYTHON_SLUGS = []
+
+
+def python_details(python_name):
+    two_or_three = subprocess.check_output(
+        [python_name, "-c", "import sys;print(sys.version)"])[0]
+    slug = 'python' + two_or_three
+    if slug not in SEEN_PYTHON_SLUGS:
+        SEEN_PYTHON_SLUGS.append(slug)
+        return {'name': python_name,
+                'slug': slug}
+    else:
+        raise ValueError("only one %s can be defined!" % slug)
 
 
 def parse_args(args=None):
@@ -30,6 +46,10 @@ def parse_args(args=None):
     build_parser.add_argument('--aux', action='append',
                               help='extra directories to include, in form'
                               ' name=/path/to/dir.')
+
+    build_parser.add_argument('--python', action='append', required=True,
+                              type=python_details,
+                              help="build wheels for this python")
 
     build_parser.add_argument(
         '--static',

--- a/no_drama/__main__.py
+++ b/no_drama/__main__.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import argparse
+import json
 import subprocess
 import sys
 
@@ -15,10 +16,15 @@ def python_details(python_name):
     two_or_three = subprocess.check_output(
         [python_name, "-c", "import sys;print(sys.version)"])[0]
     slug = 'python' + two_or_three
+    supported_tags = [tuple(l) for l in json.loads(
+        subprocess.check_output(
+            [python_name,
+             '-c', 'import json;from pip._internal import pep425tags;print(json.dumps(pep425tags.get_supported()))']))]
     if slug not in SEEN_PYTHON_SLUGS:
         SEEN_PYTHON_SLUGS.append(slug)
         return {'name': python_name,
-                'slug': slug}
+                'slug': slug,
+                'supported_tags': supported_tags}
     else:
         raise ValueError("only one %s can be defined!" % slug)
 

--- a/no_drama/build.py
+++ b/no_drama/build.py
@@ -4,6 +4,7 @@ import os
 import os.path
 import shutil
 
+from pip._internal import wheel
 from no_drama.context import temp_directory
 from no_drama.executable import make_executable
 from no_drama.pip_automation import save_wheels
@@ -13,6 +14,18 @@ this_file = os.path.realpath(__file__)
 this_directory = os.path.dirname(this_file)
 build_skel = os.path.join(this_directory, 'build_skel')
 
+
+def wheel_tags_iterator(wheel_name):
+    py_tags, abi_tags, platform_tags= (wheel_name.split('-')[-3:])
+    for py_tag in py_tags.split('.'):
+        for abi_tag in abi_tags.split('.'):
+            for platform_tag in platform_tags.split('.'):
+                yield [py_tag,abi_tag,platform_tag]
+
+
+def supported_wheels_filter(wheel_paths, supported_tags):
+    return [path for path in wheel_paths if wheel.Wheel(
+        path).supported(tags=supported_tags)]
 
 def stage_bundle(cli_args):
     archive_basename = "%s_%s" % (cli_args.name, cli_args.label)
@@ -33,21 +46,31 @@ def stage_bundle(cli_args):
         bootstrap_wheels = ['virtualenv', 'pip', 'setuptools', 'wheel']
         bootstrap_wheels_destination = os.path.join(
             build_dir, 'bootstrap_wheels')
-        save_wheels(cli_args.python[0]['name'], packages=bootstrap_wheels,
+        save_wheels(cli_args.python, packages=bootstrap_wheels,
                     destination=bootstrap_wheels_destination)
 
         # move just the wheels we want into the bundle dir
-        bootstrap_wheels = glob.glob(
-            os.path.join(bootstrap_wheels_destination, '*.whl'))
+        wheel_destination = os.path.join(
+            build_dir, 'wheels')
+
+
+        if cli_args.r:
+            save_wheels(
+                cli_args.python,
+                destination=wheel_destination,
+                requirements_paths=cli_args.r)
+
+        wheels = glob.glob(
+            os.path.join(wheel_destination, '*.whl'))
+
+        # write a requirements file for each python version
         for python in cli_args.python:
-            wheel_destination = os.path.join(
-                build_dir, 'wheels-'+python['slug'])
-            if cli_args.r:
-                save_wheels(
-                    python['name'],
-                    destination=wheel_destination,
-                    requirements_paths=cli_args.r,
-                    pythonpaths=bootstrap_wheels)
+            requirements_file_path = os.path.join(
+                build_dir,'requirements-%s.txt' % python['slug'])
+            compatible_wheels = supported_wheels_filter(wheels, python['supported_tags'])
+            reqlines = [os.path.relpath(p, build_dir) + '\n' for p in compatible_wheels]
+            with open(requirements_file_path, 'wb') as reqfile:
+                reqfile.writelines(reqlines)
 
         # copy django project into bundle dir
         project_complete_path = os.path.join(

--- a/no_drama/build.py
+++ b/no_drama/build.py
@@ -1,4 +1,5 @@
 import json
+import glob
 import os
 import os.path
 import shutil
@@ -29,18 +30,24 @@ def stage_bundle(cli_args):
         shutil.copytree(build_skel, build_dir)
 
         # these are wheels needed during activation
-        bootstrap_wheels = ['virtualenv', 'pip', 'setuptools']
+        bootstrap_wheels = ['virtualenv', 'pip', 'setuptools', 'wheel']
         bootstrap_wheels_destination = os.path.join(
             build_dir, 'bootstrap_wheels')
-        save_wheels(packages=bootstrap_wheels,
+        save_wheels(cli_args.python[0]['name'], packages=bootstrap_wheels,
                     destination=bootstrap_wheels_destination)
 
         # move just the wheels we want into the bundle dir
-        wheel_destination = os.path.join(build_dir, 'wheels')
-        if cli_args.r:
-            save_wheels(
-                destination=wheel_destination,
-                requirements_paths=cli_args.r)
+        bootstrap_wheels = glob.glob(
+            os.path.join(bootstrap_wheels_destination, '*.whl'))
+        for python in cli_args.python:
+            wheel_destination = os.path.join(
+                build_dir, 'wheels-'+python['slug'])
+            if cli_args.r:
+                save_wheels(
+                    python['name'],
+                    destination=wheel_destination,
+                    requirements_paths=cli_args.r,
+                    pythonpaths=bootstrap_wheels)
 
         # copy django project into bundle dir
         project_complete_path = os.path.join(

--- a/no_drama/pip_automation.py
+++ b/no_drama/pip_automation.py
@@ -2,8 +2,7 @@ import os
 import subprocess
 
 
-def save_wheels(python_name, destination, packages=[], requirements_paths=[],
-                pythonpaths=None):
+def save_wheels(pythons, destination, packages=[], requirements_paths=[]):
     """Collect Python wheels for all packages and requirements.
 
     Given a list of packages and requirements files, invoke "pip wheel" to
@@ -16,12 +15,16 @@ def save_wheels(python_name, destination, packages=[], requirements_paths=[],
     # python -m pip wheel --wheel-dir=dest p1 p2 p3 -r req1.txt -r req2.txt
     # https://pip.pypa.io/en/stable/user_guide/#using-pip-from-your-program
     environment = os.environ.copy()
-    if pythonpaths:
-        environment['PYTHONPATH'] = ':'.join(pythonpaths)
-    subprocess.check_call(
-        [python_name, '-m', 'pip'] +
-        ['wheel', '--wheel-dir=%s' % destination] +
-        packages +
-        ['-r' + path for path in requirements_paths],
-        env=environment
-    )
+
+    for python in pythons:
+        subprocess.check_call(
+            [python['name'], '-m', 'pip'] +
+            ['wheel', '--wheel-dir=%s' % destination,
+            '--find-links=%s' % destination] +
+            packages +
+            ['-r' + path for path in requirements_paths],
+            env=environment
+        )
+
+
+

--- a/no_drama/pip_automation.py
+++ b/no_drama/pip_automation.py
@@ -1,8 +1,9 @@
+import os
 import subprocess
-import sys
 
 
-def save_wheels(destination, packages=[], requirements_paths=[]):
+def save_wheels(python_name, destination, packages=[], requirements_paths=[],
+                pythonpaths=None):
     """Collect Python wheels for all packages and requirements.
 
     Given a list of packages and requirements files, invoke "pip wheel" to
@@ -14,9 +15,13 @@ def save_wheels(destination, packages=[], requirements_paths=[]):
     #
     # python -m pip wheel --wheel-dir=dest p1 p2 p3 -r req1.txt -r req2.txt
     # https://pip.pypa.io/en/stable/user_guide/#using-pip-from-your-program
+    environment = os.environ.copy()
+    if pythonpaths:
+        environment['PYTHONPATH'] = ':'.join(pythonpaths)
     subprocess.check_call(
-        [sys.executable, '-m', 'pip'] +
+        [python_name, '-m', 'pip'] +
         ['wheel', '--wheel-dir=%s' % destination] +
         packages +
-        ['-r' + path for path in requirements_paths]
+        ['-r' + path for path in requirements_paths],
+        env=environment
     )


### PR DESCRIPTION
This implements *half* of support for building DFD packages that support both Python 2 and 3.  This is implemented by a new `--python` argument, that must be specified *at least* once (and in practice, no more than twice)

`no-drama build . cfgov cfgov  --python=python2 --python=python3 --python=python2 -r requirements/deployment.txt `

Instead of a single 'wheels' directory in the resulting package, there will be one or both of `wheels-python2` and `wheels-python3`.

The activation/deployment side of the house hasn't been touched yet, so these packages are not yet actually usable.