### PR TITLE
Add .python-version to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ __pycache__/
 *.py[cod]
 .env
 .eggs
+.python-version
 
 # Django #
 #################


### PR DESCRIPTION
This change adds .python-version to .gitignore, so that local usage of pyenv doesn't clutter the git status.