### PR TITLE
Manage.py

### DIFF
--- a/no_drama/build.py
+++ b/no_drama/build.py
@@ -60,11 +60,6 @@ execfile('%s/manage.py')
         with open(manage_py_path, 'w') as manage_py:
             manage_py.write(manage_py_script)
 
-        # make the manage.py script executable
-        mode = os.stat(manage_py_path).st_mode
-        mode |= (mode & 0o444) >> 2    # copy R bits to X
-        os.chmod(manage_py_path, mode)
-
         # install paths.d/0_build.json, so activate.sh can find the django_root
         paths_d = os.path.join(build_dir, 'paths.d')
         initial_paths_path = os.path.join(paths_d, '0_build.json')

--- a/no_drama/build.py
+++ b/no_drama/build.py
@@ -56,8 +56,14 @@ def stage_bundle(cli_args):
 "exec" "`dirname $0`/venv/bin/python" "$0" "$@"
 execfile('%s/manage.py')
        ''' % project_slug
-        with open(os.path.join(build_dir, 'manage.py'), 'w') as manage_py:
+        manage_py_path = os.path.join(build_dir, 'manage.py')
+        with open(manage_py_path, 'w') as manage_py:
             manage_py.write(manage_py_script)
+
+        # make the manage.py script executable
+        mode = os.stat(manage_py_path).st_mode
+        mode |= (mode & 0o444) >> 2    # copy R bits to X
+        os.chmod(manage_py_path, mode)
 
         # install paths.d/0_build.json, so activate.sh can find the django_root
         paths_d = os.path.join(build_dir, 'paths.d')

--- a/no_drama/build.py
+++ b/no_drama/build.py
@@ -50,6 +50,15 @@ def stage_bundle(cli_args):
         project_destination = os.path.join(build_dir, project_slug)
         shutil.copytree(cli_args.project_path, project_destination)
 
+        # create a 'manage.py' script that runs in the virtualenv
+
+        manage_py_script = '''#!/bin/sh
+"exec" "`dirname $0`/venv/bin/python" "$0" "$@"
+execfile('%s/manage.py')
+       ''' % project_slug
+        with open(os.path.join(build_dir, 'manage.py'), 'w') as manage_py:
+            manage_py.write(manage_py_script)
+
         # install paths.d/0_build.json, so activate.sh can find the django_root
         paths_d = os.path.join(build_dir, 'paths.d')
         initial_paths_path = os.path.join(paths_d, '0_build.json')

--- a/no_drama/build_skel/activate.sh
+++ b/no_drama/build_skel/activate.sh
@@ -19,3 +19,5 @@ echo `$DIR/venv/bin/python $DIR/lib/dfd.py django_root`>>$SITE_PACKAGES/no_drama
 
 $DIR/venv/bin/pip install $DIR/wheels/*.whl --force
 $DIR/venv/bin/python -m activate_phase2
+
+chmod +x $DIR/manage.py


### PR DESCRIPTION
This adds a manage.py script to the root of the drama free django build. It's useful mostly because it comes configured to use the virtualenv, and then hands control to the manage.py shipped in project root.

You can then run commands like 'collectstatic' and 'migrate' using ./manage.py, instead of ./venv/bin/django-admin 

Example: https://github.com/cfpb/cfgov-refresh/blob/dfd-manage.py/docker/drama-free-django/_test.sh#L62