### PR TITLE
Only set STATIC_ROOT if provided

### DIFF
--- a/no_drama/build_skel/lib/dfd.py
+++ b/no_drama/build_skel/lib/dfd.py
@@ -35,18 +35,29 @@ for pathfile in pathfiles:
     pathfile.close()
 
 
+def make_path(relpath):
+    return os.path.normpath(os.path.join(root, relpath))
+
+
 def get_path(name):
-    relpath = paths[name]
-    if relpath is not None and bool(relpath) is True:
-        joined = os.path.join(root, relpath)
-        return os.path.normpath(joined)
-    else:
+    relpath = paths.get(name)
+
+    if not relpath:
         raise KeyError('no path found for %s' % name)
 
+    return make_path(relpath)
+
 def get_path_if_exists(name):
-    path = get_path(name)
-    if os.path.exists(path):
-        return path
+    if name not in paths:
+        raise KeyError('no path found for %s' % name)
+
+    relpath = paths[name]
+
+    if relpath:
+        path = make_path(relpath)
+
+        if os.path.exists(path):
+            return path
 
 
 if __name__ == '__main__':

--- a/no_drama/build_skel/lib/dfd_settings.py
+++ b/no_drama/build_skel/lib/dfd_settings.py
@@ -12,7 +12,7 @@ else:
 
 static_in = dfd.get_path('static_in')
 build_static_in = dfd.get_path('build_static_in')
-static_out = dfd.get_path('static_out')
+static_out = dfd.get_path_if_exists('static_out')
 secret_key_path = dfd.get_path_if_exists('secret_key')
 media_root_path = dfd.get_path_if_exists('persistent_media_root')
 
@@ -34,7 +34,8 @@ if EXTENDED_STATICFILES_DIRS:
     else:
         STATICFILES_DIRS = EXTENDED_STATICFILES_DIRS
 
-STATIC_ROOT = static_out
+if static_out:
+    STATIC_ROOT = static_out
 
 if media_root_path:
     MEDIA_ROOT = media_root_path


### PR DESCRIPTION
Currently drama-free-django always sets the Django setting STATIC_ROOT. This change makes it possible to skip this, by setting the "static_out" path to a falsey value.

This also slightly modifies the behavior of get_path_if_exists to allow for empty paths, still raising an error if the path key doesn't exist.