### PR TITLE
Make extra STATICFILES_DIRS optional

### DIFF
--- a/no_drama/build_skel/lib/dfd_settings.py
+++ b/no_drama/build_skel/lib/dfd_settings.py
@@ -10,8 +10,8 @@ else:
     raise ImportError
 
 
-static_in = dfd.get_path('static_in')
-build_static_in = dfd.get_path('build_static_in')
+static_in = dfd.get_path_if_exists('static_in')
+build_static_in = dfd.get_path_if_exists('build_static_in')
 static_out = dfd.get_path_if_exists('static_out')
 secret_key_path = dfd.get_path_if_exists('secret_key')
 media_root_path = dfd.get_path_if_exists('persistent_media_root')
@@ -22,7 +22,7 @@ if secret_key_path:
 
 EXTENDED_STATICFILES_DIRS = []
 
-for location in [l for l in [static_in, build_static_in] if os.path.exists(l)]:
+for location in [l for l in [static_in, build_static_in] if l and os.path.exists(l)]:
     for filename in os.listdir(location):
         path = os.path.join(location, filename)
         if os.path.isdir(path):


### PR DESCRIPTION
Currently drama-free-django always tries to append to the Django [`STATICFILES_DIRS`](https://docs.djangoproject.com/en/1.11/ref/settings/#std:setting-STATICFILES_DIRS) setting with a list of subdirectories of two locations, specified by the `static_in` and `build_static_in` keys. These default to two different locations for a 'static.in' subdirectory.

Currently cf.gov relies on this behavior to pull in staticfiles from a static.in subdirectory, but it would be nice to do this directly in Django settings, instead of relying on DFD.

This change makes it possible to disable this behavior by setting one or both of the `static_in` and `build_static_in` keys to None.

This is a similar change to #26, which made setting `STATIC_ROOT` optional.